### PR TITLE
[UPDATE] Oauth URL 변경 및 API 문서 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+### API
+
+API는 https://127.0.0.1 뒤에 /api/ 를 붙여서 사용합니다.
+
+GET /api/session
+
+```
+HTTP 200 OK
+{
+    "session_id": session_id,
+}
+
+HTTP 401 Unauthorized
+{
+    "message": "로그인이 필요합니다.",
+}
+```
+
+DELETE /api/session
+
+```
+HTTP 204 No Content
+{
+    "message": "로그아웃 되었습니다."
+}
+```
+
+GET /api/me
+
+```
+HTTP 200 OK
+{
+    "intra_id": "hujeong",
+    "created_at": "2024-03-25T17:11:57.775105+09:00",
+    "game_status": false,
+    "win": 0,
+    "lose": 0
+}
+
+HTTP 401 Unauthorized
+{
+    "message": "로그인이 필요합니다."
+}
+```

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -11,12 +11,7 @@ class OauthAPI(APIView):
     def get(self, request):
         intra_id = self.__get_intra_id(request)
         request.session['intra_id'] = intra_id
-        response = Response(
-            {
-                "session_id": request.session.session_key,
-            },
-            status=status.HTTP_200_OK)
-        return redirect(FRONT_URL, response=response)
+        return redirect(FRONT_URL)
     
     def __get_intra_id(self, request):
         access_token = self.__get_access_token(request)

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -26,7 +26,7 @@ server {
     }
 
     location /api {
-        proxy_pass http://backend:8080;
+        proxy_pass http://backend:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/frontend/src/components/login/Login.js
+++ b/frontend/src/components/login/Login.js
@@ -12,7 +12,7 @@ export default class Login extends Component {
     const loginStatus = this.store.getState().isLoggedIn;
     const languageId = this.store.getState().languageId;
     const OAuth_URL =
-      "https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-b8ee714debb1a7c3febef1c78bc4eacb56043624455068279b88fe88c991c42e&redirect_uri=http%3A%2F%2F127.0.0.1%3A8000%2Fapi%2Foauth&response_type=code";
+      "https://api.intra.42.fr/oauth/authorize?client_id=u-s4t2ud-b8ee714debb1a7c3febef1c78bc4eacb56043624455068279b88fe88c991c42e&redirect_uri=https%3A%2F%2F127.0.0.1%2Fapi%2Foauth&response_type=code";
 
     if (loginStatus === true) {
       router.push("/");


### PR DESCRIPTION
### 구현내용
- Oauth 등록 주소를 바꿨습니다.
- API 문서 작성했습니다.
### 설명
- https 통신을 할 수 있게 API 리다이렉트 주소를 바꿨습니다. 기존에는 백엔드 서버로 바로 리다이렉트가 되는 구조였는데 nginx를 경유합니다.
- nginx 설정 파일 작성할 때 실수가 있어서 수정했습니다. 백엔드 포트는 8080이 아니라 8000입니다.
- USER 모듈을 삭제해서 API가 간단합니다. /api/session 으로 GET 요청하면 로그인 되어있는지 확인할 수 있고 /api/me로 GET 요청 시 유저 정보를 받아올 수 있습니다. README에 작성했으니 확인부탁드려요.