### PR TITLE
Hotfix: Users url 삭제

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,9 +1,8 @@
 from django.urls import path
-from .views import UsersAPI, OauthAPI, MeAPI, SessionAPI, TestAPI, LogoutAPI
+from .views import OauthAPI, MeAPI, SessionAPI, TestAPI, LogoutAPI
 
 urlpatterns = [
     path('oauth/', OauthAPI.as_view()),
-    path('users/', UsersAPI.as_view()),
     path('me/', MeAPI.as_view()),
     path('test/', TestAPI.as_view()),
     path('session/', SessionAPI.as_view()),

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -136,6 +136,7 @@ USE_I18N = True
 
 USE_TZ = True
 
+AUTH_USER_MODEL = 'api.User' #사용자 모델 설정
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/


### PR DESCRIPTION
### 구현내용
- Users view 삭제
- AUTH_USER_MODEL 세팅

### 설명
- Users view가 api로 있었는데 프론트에서 딱히 필요가 없을 것 같아서 지웠습니다. 그리고 세팅에서 AUTH_USER_MODEL을 설정 해줘야 권한 확인이 되는데 푸시할 때 이게 빠져있었습니다. 오류 해결!
